### PR TITLE
Add in modules endpoint so that librarian install will work

### DIFF
--- a/src/main/java/org/sonatype/nexus/repository/puppet/internal/AssetKind.java
+++ b/src/main/java/org/sonatype/nexus/repository/puppet/internal/AssetKind.java
@@ -27,6 +27,7 @@ import static org.sonatype.nexus.repository.cache.CacheControllerHolder.*;
 public enum AssetKind
 {
   MODULE_RELEASES_BY_NAME(METADATA),
+  MODULE_BY_NAME(METADATA),
   MODULE_RELEASE_BY_NAME_AND_VERSION(METADATA),
   MODULE_DOWNLOAD(CONTENT);
 

--- a/src/main/java/org/sonatype/nexus/repository/puppet/internal/PuppetRecipeSupport.groovy
+++ b/src/main/java/org/sonatype/nexus/repository/puppet/internal/PuppetRecipeSupport.groovy
@@ -115,6 +115,13 @@ abstract class PuppetRecipeSupport
   }
 
   /**
+   * Matcher for module by name
+   */
+  static Matcher moduleByNameMatcher() {
+    buildTokenMatcherForPatternAndAssetKind('/v3/modules/{user:.+}-{module:.+}', AssetKind.MODULE_BY_NAME, GET, HEAD)
+  }
+
+  /**
    * Matcher for a module release details.
    */
   static Matcher moduleReleaseByNameAndVersionMatcher() {

--- a/src/main/java/org/sonatype/nexus/repository/puppet/internal/proxy/PuppetProxyFacetImpl.java
+++ b/src/main/java/org/sonatype/nexus/repository/puppet/internal/proxy/PuppetProxyFacetImpl.java
@@ -91,6 +91,8 @@ public class PuppetProxyFacetImpl
         return getAsset(puppetPathUtils.buildModuleReleaseByNamePath(parameters));
       case MODULE_RELEASE_BY_NAME_AND_VERSION:
         return getAsset(puppetPathUtils.buildModuleReleaseByNameAndVersionPath(matcherState));
+      case MODULE_BY_NAME:
+        return getAsset(puppetPathUtils.buildModuleByNamePath(matcherState));
       case MODULE_DOWNLOAD:
         return getAsset(puppetPathUtils.buildModuleDownloadPath(matcherState));
       default:
@@ -125,6 +127,10 @@ public class PuppetProxyFacetImpl
         return putMetadata(content,
             assetKind,
             puppetPathUtils.buildModuleReleaseByNameAndVersionPath(matcherState));
+      case MODULE_BY_NAME:
+        return putMetadata(content,
+            assetKind,
+            puppetPathUtils.buildModuleByNamePath(matcherState));
       case MODULE_DOWNLOAD:
         return putModule(content,
             assetKind,

--- a/src/main/java/org/sonatype/nexus/repository/puppet/internal/proxy/PuppetProxyRecipe.groovy
+++ b/src/main/java/org/sonatype/nexus/repository/puppet/internal/proxy/PuppetProxyRecipe.groovy
@@ -83,7 +83,7 @@ class PuppetProxyRecipe
   private ViewFacet configure(final ConfigurableViewFacet facet) {
     Router.Builder builder = new Router.Builder()
 
-    [moduleReleaseByNameAndVersionMatcher(), moduleReleasesSearchByNameMatcher(), moduleDownloadMatcher()].each { matcher ->
+    [moduleReleaseByNameAndVersionMatcher(), moduleReleasesSearchByNameMatcher(), moduleDownloadMatcher(), moduleByNameMatcher()].each { matcher ->
       builder.route(new Route.Builder().matcher(matcher)
           .handler(timingHandler)
           .handler(securityHandler)

--- a/src/main/java/org/sonatype/nexus/repository/puppet/internal/util/PuppetPathUtils.java
+++ b/src/main/java/org/sonatype/nexus/repository/puppet/internal/util/PuppetPathUtils.java
@@ -58,6 +58,10 @@ public class PuppetPathUtils
     return String.format("/v3/releases/%s-%s-%s", user(matcherState), module(matcherState), version(matcherState));
   }
 
+  public String buildModuleByNamePath(final State matcherState) {
+    return String.format("/v3/modules/%s-%s", user(matcherState), module(matcherState));
+  }
+
   public String buildModuleReleaseByNamePath(final Parameters parameters) {
     if (parameters.isEmpty()) {
       return "/v3/releases";

--- a/src/test/java/org/sonatype/nexus/repository/puppet/internal/util/PuppetPathUtilsTest.java
+++ b/src/test/java/org/sonatype/nexus/repository/puppet/internal/util/PuppetPathUtilsTest.java
@@ -92,6 +92,15 @@ public class PuppetPathUtilsTest
   }
 
   @Test
+  public void buildModuleByNamePath() throws Exception {
+    setupTokens();
+
+    String result = underTest.buildModuleByNamePath(mockState);
+
+    assertThat(result, is(equalTo("/v3/modules/puppetlabs-stdlib")));
+  }
+
+  @Test
   public void buildModuleDownloadPath() throws Exception {
     setupTokens();
 


### PR DESCRIPTION
We didn't implement this endpoint when crafting the Proxy POC, and it turns out that librarian-puppet makes use of it.

This pull request makes the following changes:
* Additional matcher, route
* Small changes to ProxyImpl to allow this new AssetKind through
* New method for building a path for this endpoint

It relates to the following issue #s:
* Fixes #3 
