### PR TITLE
Remove leading slash

### DIFF
--- a/src/main/java/org/sonatype/nexus/repository/puppet/internal/util/PuppetPathUtils.java
+++ b/src/main/java/org/sonatype/nexus/repository/puppet/internal/util/PuppetPathUtils.java
@@ -55,21 +55,21 @@ public class PuppetPathUtils
   }
 
   public String buildModuleReleaseByNameAndVersionPath(final State matcherState) {
-    return String.format("/v3/releases/%s-%s-%s", user(matcherState), module(matcherState), version(matcherState));
+    return String.format("v3/releases/%s-%s-%s", user(matcherState), module(matcherState), version(matcherState));
   }
 
   public String buildModuleByNamePath(final State matcherState) {
-    return String.format("/v3/modules/%s-%s", user(matcherState), module(matcherState));
+    return String.format("v3/modules/%s-%s", user(matcherState), module(matcherState));
   }
 
   public String buildModuleReleaseByNamePath(final Parameters parameters) {
     if (parameters.isEmpty()) {
-      return "/v3/releases";
+      return "v3/releases";
     }
-    return String.format("/v3/releases?%s", Joiner.on("&").withKeyValueSeparator("=").join(parameters));
+    return String.format("v3/releases?%s", Joiner.on("&").withKeyValueSeparator("=").join(parameters));
   }
 
   public String buildModuleDownloadPath(final State matcherState) {
-    return String.format("/v3/files/%s-%s-%s.tar.gz", user(matcherState), module(matcherState), version(matcherState));
+    return String.format("v3/files/%s-%s-%s.tar.gz", user(matcherState), module(matcherState), version(matcherState));
   }
 }

--- a/src/test/java/org/sonatype/nexus/repository/puppet/internal/util/PuppetPathUtilsTest.java
+++ b/src/test/java/org/sonatype/nexus/repository/puppet/internal/util/PuppetPathUtilsTest.java
@@ -65,7 +65,7 @@ public class PuppetPathUtilsTest
     setupTokens();
     String result = underTest.buildModuleReleaseByNameAndVersionPath(mockState);
 
-    assertThat(result, is(equalTo("/v3/releases/puppetlabs-stdlib-5.1.0")));
+    assertThat(result, is(equalTo("v3/releases/puppetlabs-stdlib-5.1.0")));
   }
 
   @Test
@@ -78,7 +78,7 @@ public class PuppetPathUtilsTest
 
     String result = underTest.buildModuleReleaseByNamePath(parameters);
 
-    assertThat(result, is(equalTo("/v3/releases?module=puppetlabs-stdlib&sort_by=version")));
+    assertThat(result, is(equalTo("v3/releases?module=puppetlabs-stdlib&sort_by=version")));
   }
 
   @Test
@@ -88,7 +88,7 @@ public class PuppetPathUtilsTest
 
     String result = underTest.buildModuleReleaseByNamePath(parameters);
 
-    assertThat(result, is(equalTo("/v3/releases")));
+    assertThat(result, is(equalTo("v3/releases")));
   }
 
   @Test
@@ -97,7 +97,7 @@ public class PuppetPathUtilsTest
 
     String result = underTest.buildModuleByNamePath(mockState);
 
-    assertThat(result, is(equalTo("/v3/modules/puppetlabs-stdlib")));
+    assertThat(result, is(equalTo("v3/modules/puppetlabs-stdlib")));
   }
 
   @Test
@@ -106,7 +106,7 @@ public class PuppetPathUtilsTest
 
     String result = underTest.buildModuleDownloadPath(mockState);
 
-    assertThat(result, is(equalTo("/v3/files/puppetlabs-stdlib-5.1.0.tar.gz")));
+    assertThat(result, is(equalTo("v3/files/puppetlabs-stdlib-5.1.0.tar.gz")));
   }
 
   private void setupTokens() {


### PR DESCRIPTION
I noticed when running puppet in Nexus Repo, that we were adding a "/" before all paths, causing a weird path to exist when you use things in the UI. This PR is just a tiny ditty to remove that.

This pull request makes the following changes:
* Remove "/" from PuppetPathUtils
* Adjust tests