### PR TITLE
Fix copy and paste issue

### DIFF
--- a/src/main/resources/static/rapture/NX/puppet/view/repository/recipe/PuppetProxy.js
+++ b/src/main/resources/static/rapture/NX/puppet/view/repository/recipe/PuppetProxy.js
@@ -15,7 +15,7 @@
 /**
  * Repository "Settings" form for a Puppet Proxy repository
  */
-Ext.define('NX.helm.view.repository.recipe.PuppetProxy', {
+Ext.define('NX.coreui.view.repository.recipe.PuppetProxy', {
     extend: 'NX.coreui.view.repository.RepositorySettingsForm',
     alias: 'widget.nx-coreui-repository-puppet-proxy',
     requires: [


### PR DESCRIPTION
The page to create repositories of type puppet (hosted) was not opening for me, so I compared the javascript with the one of puppet (proxy) and noticed this probable copy paste problem.
After I fixed it, the page for puppet (hosted) is opening fine for me.

This pull request makes the following changes:

* src/main/resources/static/rapture/NX/puppet/view/repository/recipe/PuppetProxy.js
