### PR TITLE
Revert NEXUS-25906

### DIFF
--- a/src/main/resources/static/rapture/NX/puppet/util/PuppetRepositoryUrls.js
+++ b/src/main/resources/static/rapture/NX/puppet/util/PuppetRepositoryUrls.js
@@ -19,10 +19,8 @@ Ext.define('NX.puppet.util.PuppetRepositoryUrls', {
     'NX.util.Url'
   ]
 }, function(self) {
-  NX.coreui.util.RepositoryUrls.addRepositoryUrlStrategy('puppet', function(me, assetModel) {
-    var repositoryName = assetModel.get('repositoryName'), assetName = assetModel.get('name');
-    return NX.util.Url.asLink(
-      NX.util.Url.baseUrl + '/repository/' + encodeURIComponent(repositoryName) + '/' + encodeURI(assetName),
-      assetName);
-  });
+	NX.coreui.util.RepositoryUrls.addRepositoryUrlStrategy('puppet', function (assetModel) {
+      var repositoryName = assetModel.get('repositoryName'), assetName = assetModel.get('name');
+      return NX.util.Url.asLink(NX.util.Url.baseUrl + '/repository/' + repositoryName + '/' + assetName, assetName);
+    });
 });


### PR DESCRIPTION
Revert changes in [NEXUS-25906](https://issues.sonatype.org/browse/NEXUS-25906).
To apply these changes, the NXRM version should be updated to the 3.29.2-02 or later The corresponding ticket was created [NEXUS-26409](https://issues.sonatype.org/browse/NEXUS-26409)

This pull request makes the following changes:
* revert parameter of`addRepositoryUrlStrategy` JS method
